### PR TITLE
v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,23 +10,57 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 
-## 0.2.0
+This release has an [MSRV][] of 1.75.
 
-### added
+## [0.3.0] - 2024/08/15
+
+This release has an [MSRV][] of 1.75.
+
+### Added
+
+- `set_hook_with` now takes an additional argument, `on_panic_callback` which is triggered automatically on panic. ([#3] by [@simbleau])
+
+### Fixed
+
+- If a panic occurs after the first panic (which can happen in multi-threaded apps, e.g. Bevy games), it will only be logged to stdout. Hence, only the first panic that occurred is preserved. ([#3] by [@simbleau])
+
+## [0.2.0] - 2024/04/15
+
+This release has an [MSRV][] of 1.75.
+
+### Added
 
 - `FORM_TEXTAREA_ID` is now public, which has the element ID of the stack trace text area.
 - `FORM_SUBMIT_ID` is now public, which has the element ID of the submit button.
 
-### changed
+### Changed
 
-- `set_hook_with` now takes the additional argument of an HTML form structure. The previous, default form can still be used with `web_panic_report::set_default_hook_with`, however requires the new (default) cargo feature: `default-form`.
+- `set_hook_with` now takes the additional argument of an HTML form structure. The previous, default form can still be used with `web_panic_report::set_default_hook_with`, however requires the new (default) cargo feature: `default-form`. ([#2] by [@simbleau])
 
-## 0.1.1
+## [0.1.1] - 2024/03/17
 
-### changed
+This release has an [MSRV][] of 1.75.
+
+### Fixed
 
 - Any patch version of `web-sys` or `wasm-bindgen` can now be used.
 
-## 0.1.0
+## [0.1.0] - 2024/03/17
 
-- Initialize release
+This release has an [MSRV][] of 1.75.
+
+- Initialize release ([@Vrixyz] and [@simbleau])
+
+[@simbleau]: https://github.com/simbleau
+[@Vrixyz]: https://github.com/Vrixyz
+
+[#2]: https://github.com/loopystudios/web_panic_report/pull/2
+[#3]: https://github.com/loopystudios/web_panic_report/pull/3
+
+[Unreleased]: https://github.com/loopystudios/web_panic_report/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/loopystudios/web_panic_report/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/loopystudios/web_panic_report/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/loopystudios/web_panic_report/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/loopystudios/web_panic_report/releases/tag/v0.1.0
+
+[MSRV]: README.md#minimum-supported-rust-version-msrv

--- a/Readme.md
+++ b/Readme.md
@@ -72,6 +72,26 @@ You can also use a custom bug report form. See the [custom example](examples/cus
 
 - [`console_error_panic_hook`](https://github.com/rustwasm/console_error_panic_hook) - Only outputs stack trace to the console.
 
+## Minimum supported Rust Version (MSRV)
+
+This version of Web Panic Report has been verified to compile with **Rust 1.75** and later.
+
+Future versions of Web Panic Report might increase the Rust version requirement.
+It will not be treated as a breaking change and as such can even happen with small patch releases.
+
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some of Web Panic Report's dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+
+</details>
+
 ## Community
 
 All Loopy projects and development happens in the [Loopy Discord](https://discord.gg/zrjnQzdjCB). The discord is open to the public.

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -19,10 +19,17 @@ fn main() {
     );
 
     // Set the panic hook at the beginning of your program
-    web_panic_report::set_hook_with("test-container", my_form, |panic_info| {
-        web_sys::window()
-            .unwrap()
-            .alert_with_message(&panic_info.display.to_string())
-            .unwrap();
-    });
+    web_panic_report::set_hook_with(
+        "test-container",
+        my_form,
+        // No-op on panic
+        |_| {},
+        // Submit button will cause a web browser alert
+        |panic_info| {
+            web_sys::window()
+                .unwrap()
+                .alert_with_message(&panic_info.display.to_string())
+                .unwrap();
+        },
+    );
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,7 @@
 max_width = 100
-# TODO: comment_width = 100 - Wait for this to be stable
-# TODO: wrap_comments = true - Wait for this to be stable
 use_field_init_shorthand = true
 newline_style = "Unix"
-# TODO: imports_granularity = "Crate" - Wait for this to be stable.
+# TODO: Enable - Currently nightly only :(
+# wrap_comments = true
+# comment_width = 100
+# imports_granularity = "Crate"

--- a/src/default_form/mod.rs
+++ b/src/default_form/mod.rs
@@ -15,5 +15,5 @@ pub fn set_default_hook_with<F>(container_id: impl Into<String>, submit_callback
 where
     F: Fn(&WasmPanicInfo) + Send + Sync + 'static,
 {
-    crate::set_hook_with(container_id, FORM_HTML, submit_callback)
+    crate::set_hook_with(container_id, FORM_HTML, |_| {}, submit_callback)
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,4 @@
 #[test]
 fn can_set_as_hook() {
-    web_panic_report::set_hook_with("", "", |_| {});
+    web_panic_report::set_hook_with("", "", |_| {}, |_| {});
 }


### PR DESCRIPTION
## [0.3.0] - 2024/08/15

This release has an [MSRV][] of 1.75.

### Added

- `set_hook_with` now takes an additional argument, `on_panic_callback` which is triggered automatically on panic. ([#3] by [@simbleau])

### Fixed

- If a panic occurs after the first panic (which can happen in multi-threaded apps, e.g. Bevy games), it will only be logged to stdout. Hence, only the first panic that occurred is preserved. ([#3] by [@simbleau])